### PR TITLE
docs: start the v3 reference

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,6 +2,12 @@
 
 * [🚀 Getting Started](README.md)
 
+## API v3 Reference
+
+* [🛰 Overview](v3/README.md)
+  * [🌐 Positions](v3/positions.md)
+  * [🔀 Migrating from v2](v3/migrating-from-v2.md)
+
 ## API v2 Reference <a href="#endpoints" id="endpoints"></a>
 
 * [🪐 Bodies](endpoints/bodies.md)

--- a/v3/README.md
+++ b/v3/README.md
@@ -1,0 +1,81 @@
+---
+description: What changed in v3, and why
+---
+
+# 🛰 API v3 Reference
+
+v3 is a breaking redesign of the request and response shapes. v2 is unchanged and
+continues to work; nothing here affects it.
+
+{% hint style="info" %}
+v3 is being built. These pages are published as each endpoint is settled, so that
+the design can be read and argued with before it ships. Anything not yet listed
+in the sidebar is still being written.
+{% endhint %}
+
+## Three conventions
+
+Knowing these removes most of the surprises.
+
+**Numbers are numbers.** v2 returned every figure as a string, so `"41.26"` had
+to be parsed back before it could be used. v3 uses the JSON number type.
+
+**One representation per value.** v2 sent each angle twice: once as a number and
+once pre-formatted for display, as `"41° 15' 36\""`. It also sent the whole
+horizontal position twice, under `horizontal` and under a misspelled `horizonal`.
+v3 sends the number once. The formatted form is available on request through
+`include=formatted`, and the misspelling is gone.
+
+**Units are declared, not implied.** Every response carries a `meta.units` block.
+Right ascension is in hours, following astronomical convention; every other angle
+is in degrees. v2 stated this nowhere.
+
+Together these make a positions response about 60% smaller while carrying more
+information.
+
+## Sampling
+
+v2 returned one position per day, at a single time of day. Asking for an
+altitude curve meant twenty-four requests.
+
+v3 takes `from` and `to` as instants and a `step` as an ISO 8601 duration, so
+one request covers whatever resolution is wanted:
+
+```
+?from=2024-06-21T00:00:00Z&to=2024-06-22T00:00:00Z&step=PT1H
+```
+
+`step=P1D` reproduces v2's behaviour exactly, and is the default.
+
+## Time zones
+
+v2 inferred the time zone from the observer's coordinates and gave no way to
+override it, so two callers asking about the same instant received differently
+labelled timestamps and neither could ask for UTC.
+
+v3 takes an explicit `timezone`. `auto` keeps v2's behaviour and remains the
+default; `UTC` is the unambiguous choice.
+
+## Errors
+
+v2 returned the raw output of its schema validator, exposing internal paths such
+as `instance.latitude` and offering no stable code to branch on.
+
+v3 returns [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem details as
+`application/problem+json`, with a stable `type` URI and a machine-readable code
+for each parameter at fault.
+
+## Corrections
+
+Two v2 responses were wrong rather than merely awkward, and v3 fixes both.
+
+`extraInfo.phase.angel` was misspelled. It is `phase.angle` in v3.
+
+`extraInfo.phase.fraction` was wrong twice over: it was scaled to a range of 0 to
+0.067 instead of 0 to 1, and it ran backwards, reporting its largest value at new
+moon and zero at full. In v3 it is the fraction of the Moon's disc that is lit,
+from 0 at new to 1 at full.
+
+## Moving across
+
+See [Migrating from v2](migrating-from-v2.md) for a field-by-field mapping.

--- a/v3/astronomy-api-v3.yaml
+++ b/v3/astronomy-api-v3.yaml
@@ -1,0 +1,572 @@
+openapi: 3.1.0
+
+info:
+    title: AstronomyAPI
+    version: '3.0'
+    summary: Positions and events for the Sun, the Moon and the planets.
+    description: |
+        Version 3 is a breaking redesign of the v2 contract. The changes it makes,
+        and the reasons for them, are set out in `docs/migrating-v2-to-v3.md`.
+
+        Three conventions hold throughout, and knowing them removes most of the
+        surprises:
+
+        - **Numbers are numbers.** v2 returned every figure as a string; v3 uses
+          the JSON number type.
+        - **One representation per value.** v2 shipped each angle twice, once as a
+          number and once pre-formatted for display. v3 returns the number, and
+          the formatted form only when `include=formatted` asks for it.
+        - **Units are declared, not implied.** Every response carries a
+          `meta.units` block. Right ascension is in hours, following astronomical
+          convention; every other angle is in degrees.
+
+        Times are ISO 8601. Instants sent to the API may carry any offset and are
+        interpreted as the instant they name. Instants returned are UTC unless a
+        `timezone` is given, in which case they carry that zone's offset.
+    contact:
+        name: AstronomyAPI
+        url: https://astronomyapi.com
+    license:
+        name: Proprietary
+        url: https://astronomyapi.com/terms
+
+servers:
+    - url: https://api.astronomyapi.com/api/v3
+      description: Production
+
+security:
+    - applicationKey: []
+
+tags:
+    - name: Bodies
+      description: Where the Sun, the Moon and the planets are, and what they look like.
+
+paths:
+    /positions:
+        get:
+            tags: [Bodies]
+            summary: Positions of one or more bodies over a span of time
+            operationId: getPositions
+            description: |
+                Returns where each requested body appears from the observer's
+                location, sampled from `from` to `to` at intervals of `step`.
+
+                Sampling is the main thing v3 adds. v2 could only return one
+                position per day at a fixed time of day; `step` accepts any ISO
+                8601 duration, so an altitude curve is one request rather than
+                twenty-four.
+            parameters:
+                - $ref: '#/components/parameters/Bodies'
+                - $ref: '#/components/parameters/Latitude'
+                - $ref: '#/components/parameters/Longitude'
+                - $ref: '#/components/parameters/Elevation'
+                - $ref: '#/components/parameters/From'
+                - $ref: '#/components/parameters/To'
+                - $ref: '#/components/parameters/Step'
+                - $ref: '#/components/parameters/Timezone'
+                - $ref: '#/components/parameters/Origin'
+                - $ref: '#/components/parameters/Refraction'
+                - $ref: '#/components/parameters/Include'
+                - $ref: '#/components/parameters/Limit'
+                - $ref: '#/components/parameters/Cursor'
+            responses:
+                '200':
+                    description: Positions for each requested body.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PositionsResponse'
+                            examples:
+                                singleBody:
+                                    summary: Mars from London, one instant
+                                    value:
+                                        meta:
+                                            observer:
+                                                latitude: 51.4779
+                                                longitude: -0.0015
+                                                elevation: 0
+                                            timezone: Europe/London
+                                            units:
+                                                rightAscension: hours
+                                                declination: degrees
+                                                altitude: degrees
+                                                azimuth: degrees
+                                                distance: au
+                                            frames:
+                                                equatorial: J2000
+                                                horizontal: apparent, refracted
+                                            sampling:
+                                                from: '2024-06-21T11:00:00Z'
+                                                to: '2024-06-21T11:00:00Z'
+                                                step: PT1H
+                                                count: 1
+                                        data:
+                                            - body:
+                                                  id: mars
+                                                  name: Mars
+                                              samples:
+                                                  - time: '2024-06-21T11:00:00Z'
+                                                    rightAscension: 2.44012
+                                                    declination: 13.41983
+                                                    altitude: 41.26454
+                                                    azimuth: 232.99871
+                                                    distance:
+                                                        au: 1.7782248
+                                                        km: 266018470.2
+                                                    constellation:
+                                                        abbreviation: Ari
+                                                        name: Aries
+                                                    elongation: 51.52915
+                                                    magnitude: 1.00953
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '422':
+                    $ref: '#/components/responses/UnprocessableEntity'
+
+components:
+    securitySchemes:
+        applicationKey:
+            type: http
+            scheme: bearer
+            description: |
+                The application key, sent as `Authorization: Bearer <key>`. Keys are
+                never accepted in the query string, where they would be recorded in
+                logs and browser history.
+
+    parameters:
+        Bodies:
+            name: bodies
+            in: query
+            required: false
+            description: |
+                Which bodies to report, as a comma-separated list of ids. Omit to
+                get all of them.
+
+                `earth` is not available here. Seen from the Earth it is at zero
+                distance and has no direction, so v2's answer for it was arbitrary.
+            schema:
+                type: string
+                examples: ['mars,venus', 'moon']
+        Latitude:
+            name: latitude
+            in: query
+            required: true
+            description: Latitude of the observer, in degrees, positive north.
+            schema:
+                type: number
+                minimum: -90
+                maximum: 90
+                examples: [51.4779]
+        Longitude:
+            name: longitude
+            in: query
+            required: true
+            description: Longitude of the observer, in degrees, positive east.
+            schema:
+                type: number
+                minimum: -180
+                maximum: 180
+                examples: [-0.0015]
+        Elevation:
+            name: elevation
+            in: query
+            required: false
+            description: |
+                Height of the observer above sea level, in metres. Defaults to sea
+                level. The upper bound covers the highest permanent observatories.
+            schema:
+                type: number
+                default: 0
+                minimum: -500
+                maximum: 9000
+        From:
+            name: from
+            in: query
+            required: true
+            description: |
+                First instant to sample, as an ISO 8601 date or date-time. A bare
+                date means midnight UTC on that date.
+            schema:
+                type: string
+                examples: ['2024-06-21T00:00:00Z', '2024-06-21']
+        To:
+            name: to
+            in: query
+            required: true
+            description: Last instant to sample. Must not precede `from`.
+            schema:
+                type: string
+                examples: ['2024-06-22T00:00:00Z']
+        Step:
+            name: step
+            in: query
+            required: false
+            description: |
+                Interval between samples, as an ISO 8601 duration. `P1D` reproduces
+                v2's one-sample-per-day behaviour, which is the default.
+            schema:
+                type: string
+                default: P1D
+                pattern: '^P(?!$)(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$'
+                examples: [PT1H, PT15M, P1D]
+        Timezone:
+            name: timezone
+            in: query
+            required: false
+            description: |
+                IANA zone the returned instants are expressed in. `auto` derives it
+                from the observer's coordinates, which is what v2 always did and
+                remains the default. `UTC` is the unambiguous choice.
+            schema:
+                type: string
+                default: auto
+                examples: [auto, UTC, Europe/London]
+        Origin:
+            name: origin
+            in: query
+            required: false
+            description: |
+                Whether to measure from the observer's own position or from the
+                centre of the Earth. The difference is parallax, worth up to about
+                a degree for the Moon and arcseconds for the planets.
+            schema:
+                type: string
+                default: topocentric
+                enum: [topocentric, geocentric]
+        Refraction:
+            name: refraction
+            in: query
+            required: false
+            description: |
+                Whether the altitude accounts for the atmosphere bending light near
+                the horizon. `none` gives the geometric altitude.
+            schema:
+                type: string
+                default: standard
+                enum: [standard, none]
+        Include:
+            name: include
+            in: query
+            required: false
+            description: |
+                Optional extras, comma separated. `formatted` adds a parallel block
+                of sexagesimal strings for each angle, which v2 always sent whether
+                or not the caller wanted them.
+            schema:
+                type: string
+                examples: [formatted]
+        Limit:
+            name: limit
+            in: query
+            required: false
+            description: Most samples to return per body before paginating.
+            schema:
+                type: integer
+                default: 1000
+                minimum: 1
+                maximum: 10000
+        Cursor:
+            name: cursor
+            in: query
+            required: false
+            description: Opaque cursor from `meta.sampling.nextCursor`.
+            schema:
+                type: string
+
+    schemas:
+        PositionsResponse:
+            type: object
+            required: [meta, data]
+            properties:
+                meta:
+                    $ref: '#/components/schemas/Meta'
+                data:
+                    type: array
+                    description: One entry per requested body, in the order asked for.
+                    items:
+                        $ref: '#/components/schemas/BodySamples'
+
+        Meta:
+            type: object
+            required: [observer, timezone, units, frames, sampling]
+            properties:
+                observer:
+                    $ref: '#/components/schemas/Observer'
+                timezone:
+                    type: string
+                    description: IANA zone the instants below are expressed in.
+                    examples: [Europe/London]
+                units:
+                    type: object
+                    description: |
+                        The unit each quantity is in. Present so that no caller has
+                        to infer that right ascension is the one field not in
+                        degrees.
+                    additionalProperties:
+                        type: string
+                    examples:
+                        - rightAscension: hours
+                          declination: degrees
+                          altitude: degrees
+                          azimuth: degrees
+                          distance: au
+                frames:
+                    type: object
+                    description: |
+                        The reference frame each set of coordinates is referred to.
+                        Equatorial coordinates are J2000 unless stated otherwise;
+                        horizontal coordinates are apparent, meaning corrected for
+                        light travel time, the observer's motion, and refraction
+                        unless it was turned off.
+                    additionalProperties:
+                        type: string
+                sampling:
+                    $ref: '#/components/schemas/Sampling'
+
+        Observer:
+            type: object
+            required: [latitude, longitude, elevation]
+            properties:
+                latitude:
+                    type: number
+                    description: Degrees, positive north.
+                longitude:
+                    type: number
+                    description: Degrees, positive east.
+                elevation:
+                    type: number
+                    description: Metres above sea level.
+
+        Sampling:
+            type: object
+            required: [from, to, step, count]
+            properties:
+                from:
+                    type: string
+                    format: date-time
+                to:
+                    type: string
+                    format: date-time
+                step:
+                    type: string
+                    description: ISO 8601 duration between samples.
+                count:
+                    type: integer
+                    description: Samples returned per body.
+                nextCursor:
+                    type: string
+                    description: |
+                        Present only when the span was truncated by `limit`. Pass it
+                        back as `cursor` to continue.
+
+        BodySamples:
+            type: object
+            required: [body, samples]
+            properties:
+                body:
+                    $ref: '#/components/schemas/BodyIdentity'
+                samples:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Sample'
+
+        BodyIdentity:
+            type: object
+            required: [id, name]
+            properties:
+                id:
+                    type: string
+                    description: Stable lowercase identifier.
+                    examples: [mars]
+                name:
+                    type: string
+                    description: Display name.
+                    examples: [Mars]
+
+        Sample:
+            type: object
+            required:
+                - time
+                - rightAscension
+                - declination
+                - altitude
+                - azimuth
+                - distance
+                - constellation
+            properties:
+                time:
+                    type: string
+                    format: date-time
+                rightAscension:
+                    type: number
+                    description: Hours, in [0, 24).
+                declination:
+                    type: number
+                    description: Degrees, in [-90, 90].
+                altitude:
+                    type: number
+                    description: |
+                        Degrees above the horizon. Negative when the body is below
+                        it, which is a legitimate answer rather than an error.
+                azimuth:
+                    type: number
+                    description: Degrees clockwise from true north, in [0, 360).
+                distance:
+                    $ref: '#/components/schemas/Distance'
+                constellation:
+                    $ref: '#/components/schemas/Constellation'
+                elongation:
+                    type: number
+                    description: |
+                        Degrees between the body and the Sun as seen from the
+                        observer. Absent for the Sun.
+                magnitude:
+                    type: number
+                    description: Apparent visual magnitude. Smaller is brighter.
+                phase:
+                    $ref: '#/components/schemas/Phase'
+                formatted:
+                    $ref: '#/components/schemas/Formatted'
+
+        Distance:
+            type: object
+            required: [au, km]
+            properties:
+                au:
+                    type: number
+                    description: Astronomical units from the observer.
+                km:
+                    type: number
+                    description: |
+                        The same distance in kilometres. Returned so that callers do
+                        not each hard-code their own value for the astronomical
+                        unit and disagree with each other.
+
+        Constellation:
+            type: object
+            required: [abbreviation, name]
+            properties:
+                abbreviation:
+                    type: string
+                    description: |
+                        The IAU three-letter abbreviation, correctly capitalised.
+                        This is the stable identifier; v2 also returned a lowercase
+                        copy of it, which v3 drops.
+                    examples: [Ari, CVn]
+                name:
+                    type: string
+                    examples: [Aries]
+
+        Phase:
+            type: object
+            description: Returned for the Moon only.
+            required: [angle, fraction, name]
+            properties:
+                angle:
+                    type: number
+                    description: |
+                        Degrees by which the Moon leads the Sun in ecliptic
+                        longitude: 0 at new, 90 at first quarter, 180 at full.
+
+                        v2 spelled this field `angel`.
+                fraction:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    description: |
+                        Fraction of the Moon's disc that is lit, from 0 at new to 1
+                        at full.
+
+                        v2's figure for this was wrong twice over: it was scaled to
+                        a range of 0 to 0.067, and it ran backwards, reporting its
+                        largest value at new moon.
+                name:
+                    type: string
+                    enum:
+                        - New Moon
+                        - Waxing Crescent
+                        - First Quarter
+                        - Waxing Gibbous
+                        - Full Moon
+                        - Waning Gibbous
+                        - Last Quarter
+                        - Waning Crescent
+
+        Formatted:
+            type: object
+            description: |
+                Sexagesimal renderings of the angles above, present only when
+                `include=formatted` is given.
+            properties:
+                rightAscension:
+                    type: string
+                    examples: ['02h 26m 24s']
+                declination:
+                    type: string
+                    examples: ["13° 25' 12\""]
+                altitude:
+                    type: string
+                    examples: ["41° 15' 36\""]
+                azimuth:
+                    type: string
+                    examples: ["233° 0' 0\""]
+
+        Problem:
+            type: object
+            description: |
+                An error, as RFC 9457 problem details. v2 returned the raw output of
+                its schema validator, which exposed internal paths such as
+                `instance.latitude` and had no stable machine-readable code.
+            required: [type, title, status]
+            properties:
+                type:
+                    type: string
+                    format: uri
+                    description: Stable identifier for the kind of problem.
+                    examples: ['https://astronomyapi.com/problems/invalid-parameter']
+                title:
+                    type: string
+                    examples: [Invalid parameter]
+                status:
+                    type: integer
+                    examples: [422]
+                detail:
+                    type: string
+                    examples: ['latitude must be between -90 and 90 degrees.']
+                errors:
+                    type: array
+                    description: One entry per parameter at fault.
+                    items:
+                        type: object
+                        required: [parameter, code, detail]
+                        properties:
+                            parameter:
+                                type: string
+                                examples: [latitude]
+                            code:
+                                type: string
+                                examples: [out_of_range]
+                            detail:
+                                type: string
+
+    responses:
+        BadRequest:
+            description: The request could not be parsed.
+            content:
+                application/problem+json:
+                    schema:
+                        $ref: '#/components/schemas/Problem'
+        Unauthorized:
+            description: The application key was missing or not recognised.
+            content:
+                application/problem+json:
+                    schema:
+                        $ref: '#/components/schemas/Problem'
+        UnprocessableEntity:
+            description: The request was understood but a parameter was unacceptable.
+            content:
+                application/problem+json:
+                    schema:
+                        $ref: '#/components/schemas/Problem'

--- a/v3/migrating-from-v2.md
+++ b/v3/migrating-from-v2.md
@@ -1,0 +1,82 @@
+---
+description: A field-by-field mapping from v2 to v3
+---
+
+# 🔀 Migrating from v2
+
+v2 is unchanged and keeps working. Move when it suits you.
+
+## Positions
+
+### The request
+
+| v2                     | v3                    | Notes                                                                 |
+| ---------------------- | --------------------- | --------------------------------------------------------------------- |
+| `/bodies/positions/{body}` | `?bodies=mars`    | A list, so several bodies need one request rather than several.        |
+| `/bodies/positions`    | omit `bodies`         | v2 made "all bodies" the meaning of an absent path segment.            |
+| `from_date`            | `from`                | Now an instant, not only a date.                                       |
+| `to_date`              | `to`                  | Now an instant, not only a date.                                       |
+| `time`                 | folded into `from`/`to` | v2 applied one time of day to every date.                            |
+| —                      | `step`                | New. ISO 8601 duration. Defaults to `P1D`, which is what v2 did.       |
+| —                      | `timezone`            | New. `auto` is v2's behaviour and the default.                         |
+| `elevation` (required) | `elevation` (optional) | Defaults to sea level.                                                |
+| `output=table\|rows`   | removed               | One shape now. Laying it out is the client's job.                      |
+| —                      | `origin`              | New. `topocentric` or `geocentric`.                                    |
+| —                      | `refraction`          | New. `standard` or `none`.                                             |
+| —                      | `include=formatted`   | New. Opt in to the sexagesimal strings v2 always sent.                 |
+
+Parameter names are camelCase throughout v3. v2 mixed `from_date` in the query
+string with `backgroundStyle` in JSON bodies.
+
+### The response
+
+| v2                                                    | v3                          |
+| ----------------------------------------------------- | --------------------------- |
+| `data.table.rows[].cells[]` or `data.rows[].positions[]` | `data[].samples[]`       |
+| `cell.date`                                           | `sample.time`               |
+| `position.equatorial.rightAscension.hours` (string)   | `sample.rightAscension` (number) |
+| `position.equatorial.declination.degrees` (string)    | `sample.declination` (number)  |
+| `position.horizontal.altitude.degrees` (string)       | `sample.altitude` (number)  |
+| `position.horizontal.azimuth.degrees` (string)        | `sample.azimuth` (number)   |
+| `position.horizonal.*`                                | removed — it was a misspelling of `horizontal` and duplicated it |
+| `*.string`                                            | `sample.formatted.*`, only with `include=formatted` |
+| `distance.fromEarth.au` (string)                      | `sample.distance.au` (number) |
+| `distance.fromEarth.km` (string)                      | `sample.distance.km` (number) |
+| `position.constellation.id`                           | removed — a lowercase copy of the abbreviation |
+| `position.constellation.short`                        | `sample.constellation.abbreviation` |
+| `position.constellation.name`                         | `sample.constellation.name` |
+| `extraInfo.elongation`                                | `sample.elongation`         |
+| `extraInfo.magnitude`                                 | `sample.magnitude`          |
+| `extraInfo.phase.angel`                               | `sample.phase.angle` — spelling corrected |
+| `extraInfo.phase.fraction`                            | `sample.phase.fraction` — **value corrected**, see below |
+| `extraInfo.phase.string`                              | `sample.phase.name`         |
+| `cell.id` / `cell.name`                               | `data[].body.id` / `.name`, once per body rather than on every sample |
+
+### Two corrections
+
+**`phase.angel` → `phase.angle`.** A misspelling in v2 that reached the wire.
+
+**`phase.fraction` was wrong.** v2 reported a value between 0 and 0.067, and it
+ran backwards: largest at new moon, zero at full. v3 reports the fraction of the
+Moon's disc that is lit, 0 at new and 1 at full. Anything that compensated for
+the old behaviour needs unwinding.
+
+### Precision
+
+v2 rounded angles to two decimal places, which is 36 arcseconds — far coarser
+than the underlying calculation. v3 returns five decimal places, about 0.04
+arcseconds. Parsers that assumed a fixed width need to stop assuming it.
+
+### Errors
+
+| v2                                              | v3                                     |
+| ----------------------------------------------- | -------------------------------------- |
+| `{ "errors": [ { "property": "instance.latitude", ... } ] }` | RFC 9457 problem details |
+| 422 for every validation failure                | 400 for unparseable, 422 for unacceptable |
+| No stable code                                  | `type` URI and a per-parameter `code`  |
+
+## Bodies
+
+`earth` is no longer available from `/positions`. Seen from the Earth it is at
+zero distance and has no direction, so the numbers v2 returned for it were
+arbitrary. Requesting it returns 422.

--- a/v3/positions.md
+++ b/v3/positions.md
@@ -1,0 +1,57 @@
+---
+description: Where the Sun, the Moon and the planets are
+---
+
+# 🌐 Positions
+
+Returns where each requested body appears from the observer's location, sampled
+between two instants.
+
+One request covers as many bodies and as many instants as needed. Omit `bodies`
+to get all of them; set `step` to sample more finely than once a day.
+
+{% openapi src="astronomy-api-v3.yaml" path="/positions" method="get" %}
+[astronomy-api-v3.yaml](astronomy-api-v3.yaml)
+{% endopenapi %}
+
+## Examples
+
+Mars right now, from London:
+
+```
+GET /api/v3/positions?bodies=mars&latitude=51.4779&longitude=-0.0015
+    &from=2024-06-21T11:00:00Z&to=2024-06-21T11:00:00Z
+```
+
+The Moon's altitude every fifteen minutes through a night, in UTC:
+
+```
+GET /api/v3/positions?bodies=moon&latitude=51.4779&longitude=-0.0015
+    &from=2024-06-21T18:00:00Z&to=2024-06-22T06:00:00Z
+    &step=PT15M&timezone=UTC
+```
+
+Everything visible, once a day for a week, with sexagesimal strings alongside the
+numbers:
+
+```
+GET /api/v3/positions?latitude=51.4779&longitude=-0.0015
+    &from=2024-06-21&to=2024-06-28&step=P1D&include=formatted
+```
+
+## Notes
+
+**`earth` is not available here.** Seen from the Earth it is at zero distance and
+has no direction, so v2's answer for it was arbitrary. Asking for it returns 422.
+
+**Altitude may be negative.** A body below the horizon is a legitimate answer,
+not an error. Filter on `altitude > 0` if only what is up matters.
+
+**Refraction is applied by default**, because that is where a body appears rather
+than where it geometrically is. Pass `refraction=none` for the geometric
+altitude. The difference is about half a degree at the horizon and negligible
+overhead.
+
+**Large spans paginate.** With a fine `step` a long span can run to tens of
+thousands of samples; when `limit` is reached, `meta.sampling.nextCursor` carries
+the continuation.


### PR DESCRIPTION
Adds the v3 section, driven by an OpenAPI spec rather than the deprecated swagger blocks the v2 pages use. The spec is the same file that lives in the API repo, so the documented contract and the implemented one cannot drift.

Covers the conventions v3 settles on, the positions endpoint, and a field-by-field mapping from v2. Other endpoints follow as they are agreed.